### PR TITLE
Fix isRef typing

### DIFF
--- a/api.md
+++ b/api.md
@@ -269,7 +269,7 @@ const unwrapped = isRef(foo) ? foo.value : foo
 - **Typing**
 
     ``` ts
-    function isRef(value: any): boolean
+    function isRef<T = unknown>(value: unknown): value is Ref<T>
     ```
 
 ## `toRefs`

--- a/api.md
+++ b/api.md
@@ -269,7 +269,7 @@ const unwrapped = isRef(foo) ? foo.value : foo
 - **Typing**
 
     ``` ts
-    function isRef<T = unknown>(value: unknown): value is Ref<T>
+    function isRef(value: any): value is Ref<any>
     ```
 
 ## `toRefs`


### PR DESCRIPTION
Make `isRef` a type guard in order to property narrow types in conditionals.