### PR TITLE
fix: typing for readonly computed getter

### DIFF
--- a/api.md
+++ b/api.md
@@ -358,7 +358,7 @@ console.log(count.value) // 0
 
     ``` ts
     // read-only
-    function computed<T>(getter: () => T): ReadOnly<Ref<ReadOnly<T>>>
+    function computed<T>(getter: () => T): Readonly<Ref<Readonly<T>>>
 
     // writable
     function computed<T>(options: {

--- a/api.md
+++ b/api.md
@@ -358,7 +358,7 @@ console.log(count.value) // 0
 
     ``` ts
     // read-only
-    function computed<T>(getter: () => T): Ref<T>
+    function computed<T>(getter: () => T): ReadOnly<Ref<ReadOnly<T>>>
 
     // writable
     function computed<T>(options: {


### PR DESCRIPTION
make ref to be `readonly`

```ts
// read-only
function computed<T>(getter: () => T): Readonly<Ref<Readonly<T>>>
```