### PR TITLE
fix wrong description of toRefs api

### DIFF
--- a/api.md
+++ b/api.md
@@ -291,8 +291,8 @@ const stateAsRefs = toRefs(state)
 Type of stateAsRefs:
 
 {
-  foo: Ref<1>,
-  bar: Ref<2>
+  foo: Ref<number>,
+  bar: Ref<number>
 }
 */
 


### PR DESCRIPTION
As the concept says, [TypeScript](http://www.typescriptlang.org/docs/handbook/advanced-types.html#index-types)