### PR TITLE
Fix setup

### DIFF
--- a/api.md
+++ b/api.md
@@ -15,7 +15,7 @@ The `setup` function is a new component option. It serves as the entry point for
 
 - **Invocation Timing**
 
-    `setup` is called right after the initial props resolution when a component instance is created. Lifecycle-wise, it is called after the `beforeCreate` hook and before the `created` hook.
+    `setup` is called right after the initial props resolution when a component instance is created. Lifecycle-wise, it is called before the `beforeCreate` hook.
 
 - **Usage with Templates**
 

--- a/api.md
+++ b/api.md
@@ -291,8 +291,8 @@ const stateAsRefs = toRefs(state)
 Type of stateAsRefs:
 
 {
-  foo: Ref<1>,
-  bar: Ref<2>
+  foo: Ref<number>,
+  bar: Ref<number>
 }
 */
 


### PR DESCRIPTION
in `runtime-core` package, `setup` is called in `setupStatefulComponent`, then in `finishComponentSetup` function, `applyOptions' will be excuted for the sake of compatibility about 2.x options, where 'beforeCreate' lifecycle will be excuted.

So, `setup` is called before `beforeCreate` hook