### PR TITLE
docs: add warning about props destructure losing reactivity

### DIFF
--- a/api.md
+++ b/api.md
@@ -96,6 +96,21 @@ The `setup` function is a new component option. It serves as the entry point for
     }
     ```
 
+    Do not destructure the `props` object, as it will lose reactivity:
+
+    ``` js
+    export default {
+      props: {
+        name: String
+      },
+      setup({ name }) {
+        watch(() => {
+          console.log(`name is: ` + name) // Will not be reactive!
+        })
+      }
+    }
+    ```
+
     The `props` object is immutable for userland code during development (will emit warning if user code attempts to mutate it).
 
     The second argument provides a context object which exposes a selective list of properties that were previously exposed on `this` in 2.x APIs:


### PR DESCRIPTION
In reference to [this issue](https://github.com/vuejs/composition-api/issues/156) in the Vue 2.x plugin.

Is it possible to instead wrap `props` in `toRefs` so destructuring is possible? If not, it might be worthwhile to have a note here explaining the rationale (as is done elsewhere in the docs).