### PR TITLE
docs: Add documentation for getCurrentInstance in API

### DIFF
--- a/api.md
+++ b/api.md
@@ -628,6 +628,25 @@ copy.count++ // warning!
     ): StopHandle
     ```
 
+## getCurrentInstance
+
+Provides the current component instance (`vm`) where instance properties can be accessed.
+
+```js
+import { getCurrentInstance, ref } from '@vue/composition-api'
+
+const MyComponent = {
+  setup() {
+    const counter = ref(0)
+    const vm = getCurrentInstance()
+
+    vm.$on('increment', () => {
+        counter.value += 1
+    })
+  }
+}
+```
+
 ## Lifecycle Hooks
 
 Lifecycle hooks can be registered with directly imported `onXXX` functions:


### PR DESCRIPTION
This documents `getCurrentInstance` which currently has no mention in the API docs.

There's also an open question as to whether `onMounted` setting `this` is intentional and should be documented - stemming from [this issue](https://github.com/vuejs/composition-api/issues/206).