### PR TITLE
Update SetupContext interface (remove parent/root)

### DIFF
--- a/api.md
+++ b/api.md
@@ -166,8 +166,6 @@ The `setup` function is a new component option. It serves as the entry point for
     interface SetupContext {
       attrs: Data
       slots: Slots
-      parent: ComponentInstance | null
-      root: ComponentInstance
       emit: ((event: string, ...args: unknown[]) => void)
     }
 


### PR DESCRIPTION
It seems there was a time when `parent` and `root` existed in `SetupContext`...

As far as I've seen in, [they have been removed](https://github.com/vuejs/vue-next/commit/5a754aac8146dda0b1dbdf8e9ef61bf7946ea8ae#diff-73922352ee6aca1980da19fc10476f87).

<hr>

(BTW, the other [currently open PR](https://github.com/vuejs/composition-api-rfc/pull/17) actually contains the related information I was looking for.)