### PR TITLE
docs(index.md): fix typo and english grammar

### DIFF
--- a/index.md
+++ b/index.md
@@ -760,7 +760,7 @@ Any JavaScript program starts with an entry file (think of it as the `setup()` f
 
 ## Adoption strategy
 
-The Composition API is purely additive and does not affect / deprecate any existing 2.x APIs. It has been made available as a 2.x plugin via the [`@vue/composition` library](https://github.com/vuejs/composition-api/). The library's primary goal is to provide a way to experiment with the API and to collect feedback. The current implementation is up-to-date with this proposal, but may contain minor inconsistencies due to technical constraints of being a plugin. It may also receive braking changes as this proposal is updated, so we do not recommend using it in production at this stage.
+The Composition API is purely additive and does not affect / deprecate any existing 2.x APIs. It has been made available as a 2.x plugin via the [`@vue/composition` library](https://github.com/vuejs/composition-api/). The library's primary goal is to provide a way to experiment with the API and to collect feedback. The current implementation is up-to-date with this proposal, but may contain minor inconsistencies due to technical constraints of being a plugin. It may also receive breaking changes as this proposal is updated, so we do not recommend using it in production at this stage.
 
 We intend to ship the API as built-in in 3.0. It will be usable alongside existing 2.x options.
 

--- a/index.md
+++ b/index.md
@@ -730,7 +730,7 @@ To sum up, there are two viable styles:
 
 2. Use `reactive` whenever you can, and remember to use `toRefs` when returning reactive objects from composition functions. This reduces the mental overhead of refs but does not eliminate the need to be familiar with the concept.
 
-At this stage, we believe it is too early to mandate a best practice on `ref` vs. `reactive`. We recommend you to go with the style that aligns with your mental model better from the two options above. We will be collecting real world user feedback and eventually provide more definitive guidance on this topic.
+At this stage, we believe it is too early to mandate a best practice on `ref` vs. `reactive`. We recommend you go with the style that aligns with your mental model better from the two options above. We will be collecting real world user feedback and eventually provide more definitive guidance on this topic.
 
 ### Verbosity of the Return Statement
 


### PR DESCRIPTION
Dear maintainer(s),

I found a typo (fae2b9f) and possible English grammatical error (17e9275) when I was reading the RFC. Please find what changes these two commits have introduced in more detail.

Please note that the English language is not my first language. Please drop the commit (17e9275) in case any of you object to my suggestion.

The PR consists of two commits and each of them changes a word or two. Please squash the two commits into one as appropriate based on your project rules.

Regards,

@shoichiaizawa